### PR TITLE
Allow limited semver-based updates of the lz4 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "rm -rf lib/ && yarn build"
   },
   "dependencies": {
-    "lz4": "0.6.0"
+    "lz4": "~0.6.0"
   },
   "devDependencies": {
     "@types/node": "^10.11.2",


### PR DESCRIPTION
lz4 0.6.0 doesn't work with NodeJS 12, support for that was added with lz4 0.6.3.

This PR changes the way this package depends on lz4 so that that update gets picked up automatically.