### PR TITLE
Simplify the compress and decompress functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,16 +19,10 @@ class LZ4Codec {
         };
     }
     async compress(encoder) {
-        return await new Promise(resolve => {
-            const compressedBuffer = lz4_1.encode(encoder.buffer, this.options);
-            return resolve(compressedBuffer);
-        });
+        return lz4_1.encode(encoder.buffer, this.options);
     }
     async decompress(buffer) {
-        return await new Promise(resolve => {
-            const decompressedBuffer = lz4_1.decode(buffer);
-            return resolve(decompressedBuffer);
-        });
+        return lz4_1.decode(buffer);
     }
 }
 exports.default = LZ4Codec;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,17 +56,11 @@ export default class LZ4Codec {
     constructor(private options?: LZ4Options) { }
 
     private async compress(encoder: { buffer: Buffer }): Promise<Buffer> {
-        return await new Promise<Buffer>(resolve => {
-            const compressedBuffer: Buffer = encode(encoder.buffer, this.options);
-            return resolve(compressedBuffer);
-        });
+        return encode(encoder.buffer, this.options);
     }
 
     private async decompress(buffer: Buffer): Promise<Buffer> {
-        return await new Promise<Buffer>(resolve => {
-            const decompressedBuffer = decode(buffer);
-            return resolve(decompressedBuffer);
-        });
+        return decode(buffer);
     }
 
     /**


### PR DESCRIPTION
* Drop the `await` in the `return`: This would only be relevant when this is
  inside a try-catch, otherwise it doesn't matter whether the code "awaits" here
  or in the caller (which anyways needs to understand promises)
* Drop the whole Promise-construction: The actual call into the lz4 library would
  always immediately run anyways, and blockingly resolve the promise.