### PR TITLE
Bump lz4 to a working 0.6.3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "rm -rf lib/ && yarn build"
   },
   "dependencies": {
-    "lz4": "~0.6.0"
+    "lz4": "0.6.3"
   },
   "devDependencies": {
     "@types/node": "^12.7.1",


### PR DESCRIPTION
There is an issue https://github.com/pierrec/node-lz4/issues/99 that makes version `0.6.4` of the `lz4` module not operational. Let's freeze a version on `0.6.3` before the module will be fixed.